### PR TITLE
Fix for use of ft.UserControl which is Deprecated

### DIFF
--- a/flet_timer/flet_timer.py
+++ b/flet_timer/flet_timer.py
@@ -1,29 +1,30 @@
 import threading
 import flet as ft
 from interval_timer import IntervalTimer
-from flet.core.control import Control
 from flet.core.ref import Ref
 from typing import Any, Optional
 from flet.core.types import OptionalControlEventCallable
 from flet.core.control import OptionalNumber
-
-class Timer(ft.Control):
+class Timer(ft.Container):
     def __init__(
             self, 
             name: Optional[str] = None, 
             interval_s: OptionalNumber = None, 
             callback : OptionalControlEventCallable = None,
             #
-            # Control
+            # Container
             #
-            ref: Optional[Ref] = None,
-            data: Any = None
+            *args,
+             **kwargs
             ):
     
-        Control.__init__(
+        ft.Container.__init__(
             self,
-            ref=ref,
-            data=data,
+            width=0,
+            height=0,
+            visible=False,
+            *args,
+            **kwargs
         )
         self.name = name
         self.interval_s = interval_s
@@ -33,24 +34,6 @@ class Timer(ft.Control):
 
         if callback is None:
             self.callback = lambda: print(f"Timer {self.name} ticked")
-
-    # name
-    @property
-    def name(self) -> Optional[str]:
-        return self._get_attr("name")
-
-    @name.setter
-    def name(self, value: Optional[str]):
-        self._set_attr("name", value)
-
-    # interval
-    @property
-    def interval_s(self) -> OptionalNumber:
-        return self._get_attr("interval_s")
-
-    @interval_s.setter
-    def interval_s(self, value) -> OptionalNumber:
-        self._set_attr("interval_s", value)
 
     def did_mount(self):
         self.start()
@@ -72,7 +55,7 @@ class Timer(ft.Control):
                 print(e)
 
     def build(self):
-        return ft.Container(padding=0, margin=0)
+        pass
 
     def will_unmount(self):
         self.stop()
@@ -80,6 +63,3 @@ class Timer(ft.Control):
 
     def before_update(self):
         super().before_update()
-
-    def _get_control_name(self):
-        return "timer"

--- a/flet_timer/flet_timer.py
+++ b/flet_timer/flet_timer.py
@@ -1,19 +1,56 @@
 import threading
-
 import flet as ft
 from interval_timer import IntervalTimer
+from flet.core.control import Control
+from flet.core.ref import Ref
+from typing import Any, Optional
+from flet.core.types import OptionalControlEventCallable
+from flet.core.control import OptionalNumber
 
-
-class Timer(ft.UserControl):
-    def __init__(self, name="Timer", interval_s=1, callback=None, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+class Timer(ft.Control):
+    def __init__(
+            self, 
+            name: Optional[str] = None, 
+            interval_s: OptionalNumber = None, 
+            callback : OptionalControlEventCallable = None,
+            #
+            # Control
+            #
+            ref: Optional[Ref] = None,
+            data: Any = None
+            ):
+    
+        Control.__init__(
+            self,
+            ref=ref,
+            data=data,
+        )
         self.name = name
         self.interval_s = interval_s
         self.callback = callback
         self.active = False
         self.th = threading.Thread(target=self.tick, daemon=True)
+
         if callback is None:
             self.callback = lambda: print(f"Timer {self.name} ticked")
+
+    # name
+    @property
+    def name(self) -> Optional[str]:
+        return self._get_attr("name")
+
+    @name.setter
+    def name(self, value: Optional[str]):
+        self._set_attr("name", value)
+
+    # interval
+    @property
+    def interval_s(self) -> OptionalNumber:
+        return self._get_attr("interval_s")
+
+    @interval_s.setter
+    def interval_s(self, value) -> OptionalNumber:
+        self._set_attr("interval_s", value)
 
     def did_mount(self):
         self.start()
@@ -40,3 +77,9 @@ class Timer(ft.UserControl):
     def will_unmount(self):
         self.stop()
         super().will_unmount()
+
+    def before_update(self):
+        super().before_update()
+
+    def _get_control_name(self):
+        return "timer"


### PR DESCRIPTION
Modified the inheritance from ft.UserControl (deprecated) to ft.Container and fixed the control structure for it to appear a little more formal (in comparison with flet official controls source code).

As you can see in the commits, I tried to make your timer a ft.Control type for it to be able to be added to the overlay instead of the page since it really is not a visual control, but after a talk with TheEthicalBoy (one of the contributors of flet) he told me that shouldn't be done and I rolled back and made it a Container instead.